### PR TITLE
Solution for gizmo scaling and coherence in rotation rings

### DIFF
--- a/src/client/java/mchorse/bbs_mod/film/BaseFilmController.java
+++ b/src/client/java/mchorse/bbs_mod/film/BaseFilmController.java
@@ -157,7 +157,7 @@ public abstract class BaseFilmController
             if (matrix != null)
             {
                 stack.push();
-                MatrixStackUtils.multiply(stack, matrix);
+                MatrixStackUtils.multiply(stack, MatrixStackUtils.stripScale(matrix));
 
                 if (context.map == null)
                 {

--- a/src/client/java/mchorse/bbs_mod/ui/film/replays/UIReplaysEditor.java
+++ b/src/client/java/mchorse/bbs_mod/ui/film/replays/UIReplaysEditor.java
@@ -184,8 +184,8 @@ public class UIReplaysEditor extends UIElement
     {
         String topLevel = StringUtils.fileName(key);
 
-        if (key.startsWith("pose_overlay")) return COLORS.get("pose_overlay");
-        if (key.startsWith("transform_overlay")) return COLORS.get("transform_overlay");
+        if (topLevel.startsWith("pose_overlay")) return COLORS.get("pose_overlay");
+        if (topLevel.startsWith("transform_overlay")) return COLORS.get("transform_overlay");
 
         return COLORS.getOrDefault(topLevel, Colors.ACTIVE);
     }

--- a/src/client/java/mchorse/bbs_mod/ui/forms/editors/utils/UIPickableFormRenderer.java
+++ b/src/client/java/mchorse/bbs_mod/ui/forms/editors/utils/UIPickableFormRenderer.java
@@ -140,7 +140,7 @@ public class UIPickableFormRenderer extends UIFormRenderer
 
             if (matrix != null)
             {
-                MatrixStackUtils.multiply(stack, matrix);
+                MatrixStackUtils.multiply(stack, MatrixStackUtils.stripScale(matrix));
             }
 
             Gizmo.INSTANCE.renderStencil(context.batcher.getContext().getMatrices(), this.stencilMap);
@@ -169,7 +169,7 @@ public class UIPickableFormRenderer extends UIFormRenderer
 
         if (matrix != null)
         {
-            MatrixStackUtils.multiply(stack, matrix);
+            MatrixStackUtils.multiply(stack, MatrixStackUtils.stripScale(matrix));
         }
 
         /* Draw axes */

--- a/src/client/java/mchorse/bbs_mod/ui/framework/elements/input/UIPropTransform.java
+++ b/src/client/java/mchorse/bbs_mod/ui/framework/elements/input/UIPropTransform.java
@@ -2,8 +2,6 @@ package mchorse.bbs_mod.ui.framework.elements.input;
 
 import mchorse.bbs_mod.BBSSettings;
 import mchorse.bbs_mod.graphics.window.Window;
-import mchorse.bbs_mod.BBSModClient;
-import mchorse.bbs_mod.camera.Camera;
 import mchorse.bbs_mod.l10n.keys.IKey;
 import mchorse.bbs_mod.settings.values.IValueNotifier;
 import mchorse.bbs_mod.ui.Keys;
@@ -43,7 +41,6 @@ public class UIPropTransform extends UITransform
 
     private boolean model;
     private boolean local;
-    private int rotateSign = 1;
 
     private UITransformHandler handler;
 
@@ -221,49 +218,11 @@ public class UIPropTransform extends UITransform
         this.editing = true;
         this.mode = mode;
 
-        if (this.mode == 2)
-        {
-            this.rotateSign = this.computeRotateSign();
-        }
-
         this.cache.copy(this.transform);
 
         if (!this.handler.hasParent())
         {
             context.menu.overlay.add(this.handler);
-        }
-    }
-
-    private int computeRotateSign()
-    {
-        try
-        {
-            Camera camera = BBSModClient.getCameraController().camera;
-            org.joml.Vector3f camForward = camera.getLookDirection();
-
-            /* This calculates which way the rotating gizmo turns depending on the perspective from which it is viewed
-              *The "F" keys handle perspective rotation depending on the side of the ring
-            */
-            org.joml.Vector3f axisVec = new org.joml.Vector3f(
-                this.axis == Axis.X ? 0F : 1F,
-                this.axis == Axis.Y ? 1F : 0F,
-                this.axis == Axis.Z ? 1F : 0F
-            );
-
-            Matrix3f rot = new Matrix3f()
-                .rotateX(this.model ? MathUtils.PI : 0F)
-                .mul(this.transform.createRotationMatrix());
-
-            rot.transform(axisVec);
-
-            float dot = axisVec.x * camForward.x + axisVec.y * camForward.y + axisVec.z * camForward.z;
-
-            /* This controls the ring face and which side it will rotate on */
-            return dot < 0F ? -1 : 1;
-        }
-        catch (Throwable t)
-        {
-            return 1;
         }
     }
 
@@ -449,11 +408,9 @@ public class UIPropTransform extends UITransform
                         vector3f.mul(180F / MathUtils.PI);
                     }
 
-                    int signedDx = this.mode == 2 ? (dx * this.rotateSign) : dx;
-
-                    if (this.axis == Axis.X || all) vector3f.x += factor * signedDx;
-                    if (this.axis == Axis.Y || all) vector3f.y += factor * signedDx;
-                    if (this.axis == Axis.Z || all) vector3f.z += factor * signedDx;
+                    if (this.axis == Axis.X || all) vector3f.x += factor * dx;
+                    if (this.axis == Axis.Y || all) vector3f.y += factor * dx;
+                    if (this.axis == Axis.Z || all) vector3f.z += factor * dx;
 
                     if (this.mode == 0) this.setT(null, vector3f.x, vector3f.y, vector3f.z);
                     if (this.mode == 1) this.setS(null, vector3f.x, vector3f.y, vector3f.z);

--- a/src/client/java/mchorse/bbs_mod/ui/framework/elements/input/UIPropTransform.java
+++ b/src/client/java/mchorse/bbs_mod/ui/framework/elements/input/UIPropTransform.java
@@ -239,12 +239,12 @@ public class UIPropTransform extends UITransform
         try
         {
             Camera camera = BBSModClient.getCameraController().camera;
-            Vector3f camForward = camera.getLookDirection();
+            org.joml.Vector3f camForward = camera.getLookDirection();
 
             /* This calculates which way the rotating gizmo turns depending on the perspective from which it is viewed
               *The "F" keys handle perspective rotation depending on the side of the ring
             */
-            Vector3f axisVec = new Vector3f(
+            org.joml.Vector3f axisVec = new org.joml.Vector3f(
                 this.axis == Axis.X ? 0F : 1F,
                 this.axis == Axis.Y ? 1F : 0F,
                 this.axis == Axis.Z ? 1F : 0F

--- a/src/client/java/mchorse/bbs_mod/ui/framework/elements/input/UIPropTransform.java
+++ b/src/client/java/mchorse/bbs_mod/ui/framework/elements/input/UIPropTransform.java
@@ -2,6 +2,8 @@ package mchorse.bbs_mod.ui.framework.elements.input;
 
 import mchorse.bbs_mod.BBSSettings;
 import mchorse.bbs_mod.graphics.window.Window;
+import mchorse.bbs_mod.BBSModClient;
+import mchorse.bbs_mod.camera.Camera;
 import mchorse.bbs_mod.l10n.keys.IKey;
 import mchorse.bbs_mod.settings.values.IValueNotifier;
 import mchorse.bbs_mod.ui.Keys;
@@ -41,6 +43,7 @@ public class UIPropTransform extends UITransform
 
     private boolean model;
     private boolean local;
+    private int rotateSign = 1;
 
     private UITransformHandler handler;
 
@@ -218,11 +221,49 @@ public class UIPropTransform extends UITransform
         this.editing = true;
         this.mode = mode;
 
+        if (this.mode == 2)
+        {
+            this.rotateSign = this.computeRotateSign();
+        }
+
         this.cache.copy(this.transform);
 
         if (!this.handler.hasParent())
         {
             context.menu.overlay.add(this.handler);
+        }
+    }
+
+    private int computeRotateSign()
+    {
+        try
+        {
+            Camera camera = BBSModClient.getCameraController().camera;
+            org.joml.Vector3f camForward = camera.getLookDirection();
+
+            /* This calculates which way the rotating gizmo turns depending on the perspective from which it is viewed
+              *The "F" keys handle perspective rotation depending on the side of the ring
+            */
+            org.joml.Vector3f axisVec = new org.joml.Vector3f(
+                this.axis == Axis.X ? 0F : 1F,
+                this.axis == Axis.Y ? 1F : 0F,
+                this.axis == Axis.Z ? 1F : 0F
+            );
+
+            Matrix3f rot = new Matrix3f()
+                .rotateX(this.model ? MathUtils.PI : 0F)
+                .mul(this.transform.createRotationMatrix());
+
+            rot.transform(axisVec);
+
+            float dot = axisVec.x * camForward.x + axisVec.y * camForward.y + axisVec.z * camForward.z;
+
+            /* This controls the ring face and which side it will rotate on */
+            return dot < 0F ? -1 : 1;
+        }
+        catch (Throwable t)
+        {
+            return 1;
         }
     }
 
@@ -408,9 +449,11 @@ public class UIPropTransform extends UITransform
                         vector3f.mul(180F / MathUtils.PI);
                     }
 
-                    if (this.axis == Axis.X || all) vector3f.x += factor * dx;
-                    if (this.axis == Axis.Y || all) vector3f.y += factor * dx;
-                    if (this.axis == Axis.Z || all) vector3f.z += factor * dx;
+                    int signedDx = this.mode == 2 ? (dx * this.rotateSign) : dx;
+
+                    if (this.axis == Axis.X || all) vector3f.x += factor * signedDx;
+                    if (this.axis == Axis.Y || all) vector3f.y += factor * signedDx;
+                    if (this.axis == Axis.Z || all) vector3f.z += factor * signedDx;
 
                     if (this.mode == 0) this.setT(null, vector3f.x, vector3f.y, vector3f.z);
                     if (this.mode == 1) this.setS(null, vector3f.x, vector3f.y, vector3f.z);

--- a/src/client/java/mchorse/bbs_mod/ui/framework/elements/input/UIPropTransform.java
+++ b/src/client/java/mchorse/bbs_mod/ui/framework/elements/input/UIPropTransform.java
@@ -239,12 +239,12 @@ public class UIPropTransform extends UITransform
         try
         {
             Camera camera = BBSModClient.getCameraController().camera;
-            org.joml.Vector3f camForward = camera.getLookDirection();
+            Vector3f camForward = camera.getLookDirection();
 
             /* This calculates which way the rotating gizmo turns depending on the perspective from which it is viewed
               *The "F" keys handle perspective rotation depending on the side of the ring
             */
-            org.joml.Vector3f axisVec = new org.joml.Vector3f(
+            Vector3f axisVec = new Vector3f(
                 this.axis == Axis.X ? 0F : 1F,
                 this.axis == Axis.Y ? 1F : 0F,
                 this.axis == Axis.Z ? 1F : 0F

--- a/src/client/java/mchorse/bbs_mod/utils/MatrixStackUtils.java
+++ b/src/client/java/mchorse/bbs_mod/utils/MatrixStackUtils.java
@@ -103,7 +103,6 @@ public class MatrixStackUtils
         position.m22(position.m22() / max);
     }
 
-    /* matrix that prevents the gizmo from becoming distorted when scaling a bone of the model */
     public static Matrix4f stripScale(Matrix4f matrix)
     {
         Matrix4f m = new Matrix4f(matrix);

--- a/src/client/java/mchorse/bbs_mod/utils/MatrixStackUtils.java
+++ b/src/client/java/mchorse/bbs_mod/utils/MatrixStackUtils.java
@@ -102,4 +102,37 @@ public class MatrixStackUtils
         position.m12(position.m12() / max);
         position.m22(position.m22() / max);
     }
+
+    /* matrix that prevents the gizmo from becoming distorted when scaling a bone of the model */
+    public static Matrix4f stripScale(Matrix4f matrix)
+    {
+        Matrix4f m = new Matrix4f(matrix);
+
+        float sx = (float) Math.sqrt(m.m00() * m.m00() + m.m10() * m.m10() + m.m20() * m.m20());
+        float sy = (float) Math.sqrt(m.m01() * m.m01() + m.m11() * m.m11() + m.m21() * m.m21());
+        float sz = (float) Math.sqrt(m.m02() * m.m02() + m.m12() * m.m12() + m.m22() * m.m22());
+
+        if (sx != 0F)
+        {
+            m.m00(m.m00() / sx);
+            m.m10(m.m10() / sx);
+            m.m20(m.m20() / sx);
+        }
+
+        if (sy != 0F)
+        {
+            m.m01(m.m01() / sy);
+            m.m11(m.m11() / sy);
+            m.m21(m.m21() / sy);
+        }
+
+        if (sz != 0F)
+        {
+            m.m02(m.m02() / sz);
+            m.m12(m.m12() / sz);
+            m.m22(m.m22() / sz);
+        }
+
+        return m;
+    }
 }


### PR DESCRIPTION
- These changes ensure that the gizmo doesn't distort when scaled, remaining stable and usable without issues.

- The rotation rings are inconsistent when viewed from different angles, rotating in the opposite direction instead of as intended. This change should allow them to rotate correctly depending on which side of the ring you're viewing from.